### PR TITLE
Some updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /payload.bin
 /tinyrust
 /tinyrust.ll
-/tinyrust.o
+/tinyrust.0.o
 /libtinyrust.rlib

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ echo
 ld --gc-sections -e main -T script.ld -o payload tinyrust.0.o
 objcopy -j combined -O binary payload payload.bin
 
-ENTRY=$(nm -f posix payload | grep '^main ' | awk '{print $3}')
+ENTRY=$(nm --format=posix payload | grep '^main ' | awk '{print $3}')
 nasm -f bin -o tinyrust -D entry=0x$ENTRY elf.s
 
 chmod +x tinyrust

--- a/build.sh
+++ b/build.sh
@@ -6,12 +6,12 @@ for d in rustc git cargo ar ld objcopy nasm hexdump; do
     which $d >/dev/null || (echo "Can't find $d, needed to build"; exit 1)
 done
 
-printf "Tested on rustc 1.5.0-nightly (32a8567ea 2015-10-05)\nYou have  "
+printf "Tested on rustc 1.16.0-nightly (df8debf6d 2017-01-25)"
 rustc --version
 echo
 
 if [ ! -d syscall.rs ]; then
-    git clone https://github.com/kmcallister/syscall.rs
+    git clone https://github.com/japaric/syscall.rs
     (cd syscall.rs && cargo build --release)
     echo
 fi
@@ -19,7 +19,7 @@ fi
 set -x
 
 rustc tinyrust.rs \
-    -O -C no-stack-check -C relocation-model=static \
+    -O -C relocation-model=static \
     -L syscall.rs/target/release
 
 ar x libtinyrust.rlib tinyrust.0.o

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ for d in rustc git cargo ar ld objcopy nasm hexdump; do
     which $d >/dev/null || (echo "Can't find $d, needed to build"; exit 1)
 done
 
-printf "Tested on rustc 1.16.0-nightly (df8debf6d 2017-01-25)"
+printf "Tested on rustc 1.16.0-nightly (df8debf6d 2017-01-25)\n You have  "
 rustc --version
 echo
 

--- a/elf.s
+++ b/elf.s
@@ -6,7 +6,7 @@
 
 ehdr:
     db  0x7f, "ELF"  ; magic
-    db  2, 1, 1, 0   ; 64-bits, little endian, version 1
+    db  2, 1, 1, 9   ; 64-bits, little endian, version 9(FreeBSD, linux loader ignores this)
 
     ; This padding is a perfect place to put a string constant!
     db "Hello!", 0x0A, 0

--- a/elf.s
+++ b/elf.s
@@ -20,13 +20,11 @@ ehdr:
     dd  0            ; e_flags
     dw  ehdrsize     ; e_ehsize
     dw  phdrsize     ; e_phentsize
-    dw  1            ; e_phnum
-    dw  0, 0, 0      ; e_sh*
 
 ehdrsize  equ  $ - ehdr
 
 phdr:
-    dd  1            ; p_type = loadable program segment
+    dd  1            ; p_type = loadable program segment & (e_phnum + e_sh*)
     dd  7            ; p_flags = rwx
     dq  0            ; p_offset
     dq  $$, $$       ; p_vaddr, p_paddr

--- a/script.ld
+++ b/script.ld
@@ -1,7 +1,7 @@
 SECTIONS {
-    . = 0x400078;
+    . = 0x400070;
 
-    combined . : AT(0x400078) ALIGN(1) SUBALIGN(1) {
+    combined . : AT(0x400070) ALIGN(1) SUBALIGN(1) {
         *(.text*)
         *(.data*)
         *(.rodata*)

--- a/tinyrust.rs
+++ b/tinyrust.rs
@@ -23,7 +23,7 @@ pub fn main() {
     // Make a Rust value representing the string constant we stashed
     // in the ELF file header.
     let message: &'static [u8] = unsafe {
-        mem::transmute(slice::from_raw_parts(0x00400000 as *const u8, 7))
+        mem::transmute(slice::from_raw_parts(0x00400008 as *const u8, 7))
     };
 
     write(1, message);

--- a/tinyrust.rs
+++ b/tinyrust.rs
@@ -23,7 +23,7 @@ pub fn main() {
     // Make a Rust value representing the string constant we stashed
     // in the ELF file header.
     let message: &'static [u8] = unsafe {
-        mem::transmute(slice::from_raw_parts(0x00400008 as *const u8, 7))
+        mem::transmute(slice::from_raw_parts(0x00400000 as *const u8, 7))
     };
 
     write(1, message);

--- a/tinyrust.rs
+++ b/tinyrust.rs
@@ -1,9 +1,9 @@
 #![crate_type="rlib"]
-#![feature(raw, core_intrinsics)]
+#![feature(core_intrinsics)]
 
-#[macro_use] extern crate syscall;
+#[macro_use] extern crate sc;
 
-use std::{mem, raw, intrinsics};
+use std::{mem, slice, intrinsics};
 
 fn exit(n: usize) -> ! {
     unsafe {
@@ -23,10 +23,7 @@ pub fn main() {
     // Make a Rust value representing the string constant we stashed
     // in the ELF file header.
     let message: &'static [u8] = unsafe {
-        mem::transmute(raw::Slice {
-            data: 0x00400008 as *const u8,
-            len: 7,
-        })
+        mem::transmute(slice::from_raw_parts(0x00400008 as *const u8, 7))
     };
 
     write(1, message);


### PR DESCRIPTION
- Upgrade to rustc 1.16.0-nightly (df8debf6d 2017-01-25)
- more smaller bytes(151bytes to 143bytes, by overlapped 8bytes elf header and program header)
- Works on FreeBSD